### PR TITLE
Properly support schemaless reading and writing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,13 @@ repos:
     pass_filenames: true
     types: [file, rust]
     language: system
+  - id: rust-clippy
+    name: Rust clippy
+    description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+    entry: cargo clippy --all-features --all --
+    pass_filenames: false
+    types: [file, rust]
+    language: system
 - repo: https://github.com/pre-commit/pre-commit-hooks
   sha: v2.0.0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,14 @@ repos:
     pass_filenames: true
     types: [file, rust]
     language: system
-  - id: rust-clippy
-    name: Rust clippy
-    description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-    entry: cargo clippy --all-features --all --
-    pass_filenames: false
-    types: [file, rust]
-    language: system
+    #  It fails to install on travis
+    #  - id: rust-clippy
+    #    name: Rust clippy
+    #    description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+    #    entry: cargo clippy --all-features --all --
+    #    pass_filenames: false
+    #    types: [file, rust]
+    #    language: system
 - repo: https://github.com/pre-commit/pre-commit-hooks
   sha: v2.0.0
   hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install:
   - sudo apt-get install -y python-pip python-dev python3.7 build-essential
   - pip install --user pipenv
   - rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+  - rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
   - sudo apt-get install -y python-pip python-dev python3.7 build-essential
   - pip install --user pipenv
   - rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
-  - rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
+  #  - rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 avro-rs = "0.6.5"
 
 [dependencies.pyo3]
-version = "0.6.0"
+version = "0.7.0"
 
 # TODO: remove after https://github.com/PyO3/pyo3/issues/341
 [features]

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: rust-test py-test
 rust-test:
 	cargo test --no-default-features
 
-py-test: dev-packages install static-py-test fast-py-test
+py-test: dev-packages install fast-py-test static-py-test
 
 fast-py-test:
 	pipenv run py.test tests

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,8 +1,8 @@
-from pyo3avro_rs import AvroSchema
+from pyo3avro_rs import Schema
 
 
 def run():  # type: () -> None
-    schema = AvroSchema('{"type": "string"}')
+    schema = Schema('{"type": "string"}')
 
     payload = schema.write("some-text")
     initial = schema.read(payload)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,13 @@ struct Schema {
 #[pymethods]
 impl Schema {
     #[new]
-    fn __new__(obj: &PyRawObject, input: String) {
+    fn __new__(obj: &PyRawObject, input: String) -> PyResult<()> {
         match SchemaRs::parse_str(&input) {
-            Ok(schema) => obj.init(Schema { schema }),
-            Err(e) => PyErr::new::<exceptions::ValueError, _>(format!("{}", e.as_fail()))
-                .restore(Python::acquire_gil().python()),
+            Ok(schema) => Ok(obj.init(Schema { schema })),
+            Err(e) => Err(PyErr::new::<exceptions::ValueError, _>(format!(
+                "{}",
+                e.as_fail()
+            ))),
         }
     }
 

--- a/tests/dummy_test.py
+++ b/tests/dummy_test.py
@@ -7,6 +7,5 @@ def test_dummy() -> None:
 
 
 def test_wrong_schema() -> None:
-    # should be ValueError, see https://github.com/PyO3/pyo3/issues/488
-    with pytest.raises(SystemError):
+    with pytest.raises(ValueError):
         Schema('{"type": "error"}')

--- a/tests/dummy_test.py
+++ b/tests/dummy_test.py
@@ -1,6 +1,12 @@
+import pytest
 from pyo3avro_rs import Schema
 
 
 def test_dummy() -> None:
-    schema = Schema('{"type": "string"}')
-    assert schema is not None
+    assert Schema('{"type": "string"}')
+
+
+def test_wrong_schema() -> None:
+    # should be ValueError, see https://github.com/PyO3/pyo3/issues/488
+    with pytest.raises(SystemError):
+        Schema('{"type": "error"}')

--- a/tests/dummy_test.py
+++ b/tests/dummy_test.py
@@ -1,6 +1,6 @@
-from pyo3avro_rs import AvroSchema
+from pyo3avro_rs import Schema
 
 
 def test_dummy() -> None:
-    schema = AvroSchema('{"type": "string"}')
+    schema = Schema('{"type": "string"}')
     assert schema is not None


### PR DESCRIPTION
Fixes #16 
```
Rename AvroSchema to Schema and re-add clippy that now seems to install fine
```
```
Remove all unwraps from the codebase and upgrade to pyO3 0.7.0

Even if we raise ValueError in __new__ for Schema, users will get
SystemError with cause ValuerError because of
https://github.com/PyO3/pyo3/issues/488
```
```
Fix exception raising in Schema.__new__ by returning PyResult<()>

Also add clippy to travis
```
```
Damn you travis
```